### PR TITLE
Fixes #615 (IMA): handle lying images 

### DIFF
--- a/bureaucracy/powerpoint/placeholders.py
+++ b/bureaucracy/powerpoint/placeholders.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import warnings
 
@@ -8,6 +9,8 @@ from .engines import BaseEngine
 CONTEXT_KEY_FOR_PLACEHOLDER = 'PPT_CURRENT_PLACEHOLDER'
 
 AlreadyRendered = object()
+
+logger = logging.getLogger('PLACEHOLDER_DEBUG')
 
 
 class AlreadyRenderedException(Exception):
@@ -37,7 +40,13 @@ class PlaceholderContainer:
 
     def render_picture(self, path):
         if os.path.exists(path):
-            self.placeholder = self.placeholder.insert_picture(path)
+            try:
+                self.placeholder = self.placeholder.insert_picture(path)
+            except OSError as err:
+                logger.warning("Cannot identify the image at: '{}'."
+                               "Leaving it empty and passing to the next image. "
+                               "Exception: cannot identify image file, errno={}".format(path, err.errno))
+
         else:
             warnings.warn("File '{}' does not exist.")
 

--- a/bureaucracy/powerpoint/placeholders.py
+++ b/bureaucracy/powerpoint/placeholders.py
@@ -10,7 +10,7 @@ CONTEXT_KEY_FOR_PLACEHOLDER = 'PPT_CURRENT_PLACEHOLDER'
 
 AlreadyRendered = object()
 
-logger = logging.getLogger('PLACEHOLDER_DEBUG')
+logger = logging.getLogger('bureaucracy.powerpoin')
 
 
 class AlreadyRenderedException(Exception):

--- a/tests/powerpoint/files/wrong_image_example.jpg
+++ b/tests/powerpoint/files/wrong_image_example.jpg
@@ -1,0 +1,1 @@
+Invalid URL signature

--- a/tests/powerpoint/test_templates.py
+++ b/tests/powerpoint/test_templates.py
@@ -1,7 +1,7 @@
 import hashlib
-import unittest
 import sys
 import pytest
+import unittest
 
 from testfixtures import compare, Comparison as C, LogCapture
 
@@ -195,10 +195,10 @@ def test_not_identifiable_img_placeholder(tmpdir):
         'goat_here_pls': wrong_image,
     }
 
-    with LogCapture('PLACEHOLDER_DEBUG') as l:
+    with LogCapture('bureaucracy.powerpoin') as l:
         l.clear()
         template.render(context, engine=PythonEngine())
-        l.check(('PLACEHOLDER_DEBUG',
+        l.check(('bureaucracy.powerpoin',
                 'WARNING',
                 "Cannot identify the image at: '{}'."
                 "Leaving it empty and passing to the next image. "

--- a/tests/powerpoint/test_templates.py
+++ b/tests/powerpoint/test_templates.py
@@ -1,4 +1,10 @@
 import hashlib
+import unittest
+import sys
+import pytest
+
+from testfixtures import compare, Comparison as C, LogCapture
+
 from pathlib import Path
 from unittest.mock import patch
 
@@ -175,3 +181,38 @@ def test_img_placeholder(tmpdir):
     with open(goat, 'rb') as goat_file:
         expected_img_hexdigest = hashlib.sha1(goat_file.read()).hexdigest()
     assert expected_img_hexdigest == slide.shapes[0].image.sha1
+
+
+def test_not_identifiable_img_placeholder(tmpdir):
+    test_file = str(TEST_FILES / 'simple_img.pptx')
+    template = Template(test_file)
+
+    assert len(template._presentation.slides[0].placeholders) == 1
+
+    # This is the content of the image returned by the ''wrong'' url, which raises the OSError
+    wrong_image = str(TEST_FILES / 'wrong_image_example.jpg')
+    context = {
+        'goat_here_pls': wrong_image,
+    }
+
+    with LogCapture('PLACEHOLDER_DEBUG') as l:
+        l.clear()
+        template.render(context, engine=PythonEngine())
+        l.check(('PLACEHOLDER_DEBUG',
+                'WARNING',
+                "Cannot identify the image at: '{}'."
+                "Leaving it empty and passing to the next image. "
+                "Exception: cannot identify image file, errno={}".format(wrong_image, 'None'),))
+
+    outfile = str(tmpdir.join('placeholders.pptx'))
+    template.save_to(outfile)
+
+    # check that the contents are correctly templated out
+    pres = Presentation(outfile)
+    assert len(pres.slides) == 1
+
+    slide = pres.slides[0]
+
+    # We expect that the image (which couldn't be identified) hasn't been added to the placeholder
+    with pytest.raises(AttributeError):
+        slide.shapes[0].image

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     pytest-pep8
     pytest-runner
     PyPDF2
+    testfixtures
 commands =
     py.test \
         --cov-report=xml \


### PR DESCRIPTION
Unidentifiable images log the exception and leave the placeholder empty